### PR TITLE
default renderer selection fix

### DIFF
--- a/src/sigma.export.js
+++ b/src/sigma.export.js
@@ -12,6 +12,8 @@ if (typeof window === 'undefined')
   window = {
     addEventListener: function() {}
   };
+else if(this !== window)
+  this.WebGLRenderingContext = window.WebGLRenderingContext;
 
 if (typeof exports !== 'undefined') {
   if (typeof module !== 'undefined' && module.exports)


### PR DESCRIPTION
When used from webpack all sigma modules inherit empty this object, while some modules suppose this === window. For instance renderer.def is missing .WebGLRenderingContext, fixed in this patch.