### PR TITLE
Fixed filter not working for multiple sigma instances

### DIFF
--- a/plugins/sigma.plugins.filter/sigma.plugins.filter.js
+++ b/plugins/sigma.plugins.filter/sigma.plugins.filter.js
@@ -494,10 +494,8 @@
    * @param  {sigma} s The related sigma instance.
    */
   sigma.plugins.filter = function(s) {
-    // Create filter if undefined
-    if (!filter) {
-      filter = new Filter(s);
-    }
+    // Create new filter to update the graph params
+    filter = new Filter(s);
     return filter;
   };
 


### PR DESCRIPTION
Filter plugin was working only for the first sigma instance provided to plugin constructor. All the further instances were skipped and replaced with the first one.